### PR TITLE
move htmlencode at the end

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles.pm
@@ -2529,9 +2529,6 @@ sub addevent {
   if (! defined $errormessage || $errormessage eq '') {
     $errormessage = '_(null)_';
   }
-  if ($self->get_option('htmlencode')) {
-    $self->htmlencode(\$errormessage);
-  }
   if ($self->{options}->{maxlength}) {
     $errormessage = substr $errormessage, 0, $self->{options}->{maxlength};
   }
@@ -2556,25 +2553,12 @@ sub addfirstevent {
   my $self = shift;
   my $level = shift;
   my $errormessage = shift;
-  if ($self->get_option('htmlencode')) {
-    $self->htmlencode(\$errormessage);
-  }
   if ($level =~ /^\d/) {
     $level = (qw(OK WARNING CRITICAL UNKNOWN))[$level];
   }
   unshift(@{$self->{matchlines}->{$level}}, $errormessage);
   $self->{lastmsg}->{$level} = 
       ${$self->{matchlines}->{$level}}[$#{$self->{matchlines}->{$level}}];
-}
-
-sub htmlencode {
-  my $self = shift;
-  my $pstring = shift;
-  $$pstring =~ s/&/&#38;/g;
-  $$pstring =~ s/</&#60;/g;
-  $$pstring =~ s/>/&#62;/g;
-  $$pstring =~ s/"/&#34;/g;
-  $$pstring =~ s/'/&#39;/g;
 }
 
 #

--- a/plugins-scripts/check_logfiles.pl
+++ b/plugins-scripts/check_logfiles.pl
@@ -128,6 +128,15 @@ Usage: check_logfiles [-t timeout] -f <configfile> [--searches=tag1,tag2,...]
 EOTXT
 }
 
+sub htmlencode {
+  my $self = shift;
+  my $pstring = shift;
+  $$pstring =~ s/&/&amp/g;
+  $$pstring =~ s/</&lt/g;
+  $$pstring =~ s/>/&gt/g;
+  $$pstring =~ s/"/&quot/g;
+}
+
 %commandline = ();
 my @params = (
     "timeout|t=i",
@@ -471,9 +480,15 @@ if (my $cl = Nagios::CheckLogfiles->new({
   } else {
     $cl->run();
   }
-  printf "%s%s\n%s", $cl->{exitmessage},
+  my $exitmessage      = $cl->{exitmessage};
+  my $long_exitmessage = $cl->{long_exitmessage} ? $cl->{long_exitmessage}."\n" : "";
+  if ($commandline{htmlencode}) {
+    htmlencode(\$exitmessage);
+    htmlencode(\$long_exitmessage);
+  }
+  printf "%s%s\n%s", $exitmessage,
       $cl->{perfdata} ? "|".$cl->{perfdata} : "",
-      $cl->{long_exitmessage} ? $cl->{long_exitmessage}."\n" : "";
+      $long_exitmessage;
   exit $cl->{exitcode};
 } else {
   printf "%s\n", $Nagios::CheckLogfiles::ExitMsg;


### PR DESCRIPTION
otherwise pluginoutput would possibly be encoded twice, for example
when using --sticky.
