### PR TITLE
Macro handling fixed (IB#1039797)

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles.pm
@@ -321,7 +321,7 @@ sub init_from_file {
   $self->{postscriptparams} = $postscriptparams if $postscriptparams;
   $self->{postscriptstdin} = $postscriptstdin if $postscriptstdin;
   $self->{postscriptdelay} = $postscriptdelay if $postscriptdelay;
-  $self->{macros} = $MACROS if $MACROS;
+  $self->{macros} = { %{$self->{macros}}, %$MACROS } if %$MACROS;
   $self->{timeout} = $timeout || 360000;
   $self->{pidfile} = $pidfile if $pidfile;
   $self->{privatestate} = {};


### PR DESCRIPTION
Hi,

We've found a bug in check_logifles - macros was not resolved when put in tag parmeter in @searches configuration.

This fix works for us. Please verify and fix upstream.

Regards,
Pawel