### PR TITLE
Don't alert negative patterns on initial run with allyoucaneat disabled (IB#1039911)

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles.pm
@@ -2920,7 +2920,7 @@ printf STDERR "line is %s\n", $line;
   #
   #  if patterns beginning with ! were not found, treat this as an alert.
   #
-  if ($self->{hasinversepat}) {
+  if ($self->{hasinversepat} && ($self->{likeavirgin} != 1 || $self->{options}->{allyoucaneat})) {
     foreach my $level (qw(CRITICAL WARNING)) {
       my $patcnt = -1;
       foreach my $pattern (@{$self->{negpatterns}->{$level}}) {


### PR DESCRIPTION
Hi,

This patch disables negative patterns alerts on initial run (seekfile creation) when allyoucaneat is not enabled. Allows us to skip false initial alerts.

Please verify and consider fixing in upstream sources.

Regards,
Pawel