### PR TITLE
Add option to filter by systemd unit

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles.pm
@@ -73,6 +73,7 @@ sub init {
   $self->{unstick} = $params->{unstick} || 0;
   $self->{warning} = $params->{warning} || 0;
   $self->{critical} = $params->{critical} || 0;
+  $self->{journaldunit} = $params->{journaldunit} || "";
   $self->{matchlines} = { OK => [], WARNING => [], CRITICAL => [], UNKNOWN => [] };
   $self->init_macros;
   $self->default_options({ prescript => 1, smartprescript => 0,
@@ -172,6 +173,7 @@ sub init {
       %{$_->{macros}} = %{$self->{macros}};
       $_->{tracefile} = $self->{tracefile};
       $_->{cfgbase} = $self->{cfgbase};
+      $_->{journaldunit} = $self->{journaldunit};
       if (my $search = Nagios::CheckLogfiles::Search->new($_)) {
         # maybe override default search options with global ones (ex. report)
         $search->refresh_default_options($self->get_options('report,seekfileerror,logfileerror,protocolfileerror'));

--- a/plugins-scripts/Nagios/CheckLogfiles.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles.pm
@@ -73,7 +73,6 @@ sub init {
   $self->{unstick} = $params->{unstick} || 0;
   $self->{warning} = $params->{warning} || 0;
   $self->{critical} = $params->{critical} || 0;
-  $self->{journaldunit} = $params->{journaldunit} || "";
   $self->{matchlines} = { OK => [], WARNING => [], CRITICAL => [], UNKNOWN => [] };
   $self->init_macros;
   $self->default_options({ prescript => 1, smartprescript => 0,
@@ -173,7 +172,6 @@ sub init {
       %{$_->{macros}} = %{$self->{macros}};
       $_->{tracefile} = $self->{tracefile};
       $_->{cfgbase} = $self->{cfgbase};
-      $_->{journaldunit} = $self->{journaldunit};
       if (my $search = Nagios::CheckLogfiles::Search->new($_)) {
         # maybe override default search options with global ones (ex. report)
         $search->refresh_default_options($self->get_options('report,seekfileerror,logfileerror,protocolfileerror'));

--- a/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
@@ -22,6 +22,7 @@ sub init {
   my $self = shift;
   my $params = shift;
   $self->{logfile} = "/usr/bin/journalctl";
+  $self->{journaldunit} = $params->{journald}->{unit};
   $self->default_options({ exeargs => "", });
   $self->SUPER::init($params);
 }
@@ -30,10 +31,10 @@ sub prepare {
   my $self = shift;
   $self->{options}->{nologfilenocry} = 1;
 }
-    
+
 sub analyze_situation {
   my $self = shift;
-  $self->{logmodified} = 1; 
+  $self->{logmodified} = 1;
 }
 
 sub collectfiles {

--- a/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
@@ -22,7 +22,6 @@ sub init {
   my $self = shift;
   my $params = shift;
   $self->{logfile} = "/usr/bin/journalctl";
-  $self->{journaldunit} = $params->{logfile};
   $self->default_options({ exeargs => "", });
   $self->SUPER::init($params);
 }

--- a/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
@@ -22,6 +22,7 @@ sub init {
   my $self = shift;
   my $params = shift;
   $self->{logfile} = "/usr/bin/journalctl";
+  $self->{journaldunit} = $params->{journaldunit};
   $self->default_options({ exeargs => "", });
   $self->SUPER::init($params);
 }
@@ -41,7 +42,11 @@ sub collectfiles {
   my @rotatedfiles = ();
   my $fh = new IO::File;
   if ($self->getfileisexecutable($self->{logfile})) {
-    my $cmdline = $self->{logfile}." --since '".strftime("%Y-%m-%d %H:%M:%S", localtime($self->{journald}->{since}))."'|";
+    my $cmdline = $self->{logfile};
+    if ($self->{journaldunit}) {
+      $cmdline = $cmdline." --unit '".$self->{journaldunit}."'";
+    }
+    $cmdline = $cmdline." --since '".strftime("%Y-%m-%d %H:%M:%S", localtime($self->{journald}->{since}))."'|";
     if ($fh->open($cmdline)) {
       push(@{$self->{relevantfiles}},
         { filename => $self->{logfile},

--- a/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
@@ -23,6 +23,9 @@ sub init {
   my $params = shift;
   $self->{logfile} = "/usr/bin/journalctl";
   $self->{journaldunit} = $params->{journald}->{unit};
+  if ($self->{journaldunit} and $self->{tag} eq "default") {
+    $self->{tag} = $self->{journaldunit};
+  }
   $self->default_options({ exeargs => "", });
   $self->SUPER::init($params);
 }

--- a/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
@@ -22,7 +22,7 @@ sub init {
   my $self = shift;
   my $params = shift;
   $self->{logfile} = "/usr/bin/journalctl";
-  $self->{journaldunit} = $params->{journaldunit};
+  $self->{journaldunit} = $params->{logfile};
   $self->default_options({ exeargs => "", });
   $self->SUPER::init($params);
 }

--- a/plugins-scripts/check_logfiles.pl
+++ b/plugins-scripts/check_logfiles.pl
@@ -215,6 +215,7 @@ my @params = (
     "rotatewait",
     "rununique",
     "htmlencode",
+    "journaldunit=s",
 );
 if (! GetOptions(\%commandline, @params)) {
   print_help();
@@ -461,6 +462,7 @@ if (my $cl = Nagios::CheckLogfiles->new({
     unstick => $commandline{unstick} ? $commandline{unstick} : undef,
     warning => $commandline{warning} ? $commandline{warning} : undef,
     critical => $commandline{critical} ? $commandline{critical} : undef,
+    journaldunit => $commandline{journaldunit} ? $commandline{journaldunit} : undef,
   })) {
   $cl->{verbose} = $commandline{verbose} ? 1 : 0;
   $cl->{timeout} = $commandline{timeout} ? $commandline{timeout} : 360000;

--- a/plugins-scripts/check_logfiles.pl
+++ b/plugins-scripts/check_logfiles.pl
@@ -215,7 +215,6 @@ my @params = (
     "rotatewait",
     "rununique",
     "htmlencode",
-    "journaldunit=s",
 );
 if (! GetOptions(\%commandline, @params)) {
   print_help();
@@ -462,7 +461,6 @@ if (my $cl = Nagios::CheckLogfiles->new({
     unstick => $commandline{unstick} ? $commandline{unstick} : undef,
     warning => $commandline{warning} ? $commandline{warning} : undef,
     critical => $commandline{critical} ? $commandline{critical} : undef,
-    journaldunit => $commandline{journaldunit} ? $commandline{journaldunit} : undef,
   })) {
   $cl->{verbose} = $commandline{verbose} ? 1 : 0;
   $cl->{timeout} = $commandline{timeout} ? $commandline{timeout} : 360000;

--- a/plugins-scripts/check_logfiles.pl
+++ b/plugins-scripts/check_logfiles.pl
@@ -219,7 +219,7 @@ my @params = (
 if (! GetOptions(\%commandline, @params)) {
   print_help();
   exit $ERRORS{UNKNOWN};
-} 
+}
 
 if (exists $commandline{version}) {
   print_version();
@@ -237,7 +237,7 @@ if (exists $commandline{config}) {
   $enough_info = 1;
 } elsif (exists $commandline{logfile}) {
   $enough_info = 1;
-} elsif (exists $commandline{type} && $commandline{type} =~ /^(eventlog|errpt|ipmitool|wevtutil|executable|dumpel)/) {
+} elsif (exists $commandline{type} && $commandline{type} =~ /^(eventlog|errpt|ipmitool|wevtutil|executable|dumpel|journald)/) {
   $enough_info = 1;
 } elsif (exists $commandline{deinstall}) {
   $commandline{type} = 'dummy';


### PR DESCRIPTION
Added option --journaldunit to be used with type journal.
With this option journalctl is called like:
`journalctl --unit 'NAME'`
Reducing the number of lines check_logfiles has to process.

Example:
```
check_logfiles --type journald --logfile /dev/null --warningpattern error --journaldunit test
```