### PR TITLE
Do now show journald header

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
@@ -49,7 +49,7 @@ sub collectfiles {
     if ($self->{journaldunit}) {
       $cmdline = $cmdline." --unit '".$self->{journaldunit}."'";
     }
-    $cmdline = $cmdline." --since '".strftime("%Y-%m-%d %H:%M:%S", localtime($self->{journald}->{since}))."'|";
+    $cmdline = $cmdline." -q --since '".strftime("%Y-%m-%d %H:%M:%S", localtime($self->{journald}->{since}))."'|";
     if ($fh->open($cmdline)) {
       push(@{$self->{relevantfiles}},
         { filename => $self->{logfile},


### PR DESCRIPTION
Without ``-q`` the journalctl shows a header like:
```
-- Logs begin at Wed 2016-11-30 08:49:56 CET. --
```
This line is considered part of the logs and should not be.