### PR TITLE
fixed running check_logfiles process detection in pidfile check

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles.pm
@@ -1514,7 +1514,7 @@ sub check_pidfile {
           $pidfile_status = 0;
         } else {
           $pidfile_status = 2;
-          open(KILL, "/bin/ps -o args -e|");
+          open(KILL, "/bin/ps -o pid,args -e|");
           while (<KILL>) {
             if (/^(\d+)\s+.*check_logfiles.*/) {
               if ($1 == $pid) {


### PR DESCRIPTION
The detection of running check_logfiles would not work with the command "ps -o args -e".
To properly detect the PID it should be part of the output, hence "pid" was added to "-o" parameter of ps.