### PR TITLE
Feature/multiline logs

### DIFF
--- a/t/110multiline.t
+++ b/t/110multiline.t
@@ -1,0 +1,59 @@
+#!/usr/bin/perl -w
+#
+#  110multiline.t
+#
+#  Test multiline parsing
+#
+
+use strict;
+use Test::More tests => 3;
+use Cwd;
+use lib "../plugins-scripts";
+use Nagios::CheckLogfiles::Test;
+use constant TESTDIR => ".";
+
+my $configfile = <<EOCFG;
+\$protocolsdir = "./var/tmp";
+\$seekfilesdir = "./var/tmp";
+
+\@searches = (
+  {
+    tag => 'multiline',
+    options => 'allyoucaneat',
+    multiline   => 1,
+    multilinestartpattern => '\\d{4}\\-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\- ',
+    logfile => './data/multiline.log',
+    criticalpatterns => [ 'ERROR' ]
+  },
+);
+
+EOCFG
+open CCC, ">./etc/multiline.cfg";
+print CCC $configfile;
+close CCC;
+
+my $cl = Nagios::CheckLogfiles::Test->new({ cfgfile => "./etc/multiline.cfg" });
+$cl->reset();
+$cl->run();
+diag($cl->has_result());
+diag($cl->{exitmessage});
+
+my ($protocolFile) = glob( "./var/tmp/multiline.protocol*" );
+open( PROTOCOL, "<$protocolFile" ) || fail( "Could not open protocol file '$protocolFile': $!" );
+my @content = <PROTOCOL>;
+close( PROTOCOL );
+
+my $expectedContent = qq|CRITICAL Errors in multiline.log (tag multiline)
+2017-08-07 19:51:02 - ERROR
+Test subject glitched through catcher
+Cake reward will be reduced
+2017-08-07 19:51:09 - ERROR
+.....<bzzzt>.....>...\$\%\&...:!
+<reboot initi.... cake...\%\%\&/(
+2017-08-07 19:57:37 - ERROR - but only one line really
+|;
+
+is(join( "", @content ), $expectedContent ); 
+like($cl->{exitmessage}, qr/CRITICAL - \(3 errors in multiline.protocol-.+\) - 2017-08-07 19:57:37 - ERROR - but only one line really .../ );
+ok($cl->expect_result(0, 0, 3, 0, 2));
+

--- a/t/data/multiline.log
+++ b/t/data/multiline.log
@@ -1,0 +1,20 @@
+2017-08-07 19:51:00 - INFO
+Testchamber 16 initialized
+Number of portals set to seven
+2017-08-07 19:51:02 - ERROR
+Test subject glitched through catcher
+Cake reward will be reduced
+2017-08-07 19:51:07 - INFO
+Testchamber 17 initialized
+Test subject entered with fully upgraded Portal Gun
+2017-08-07 19:51:09 - ERROR
+.....<bzzzt>.....>...$%&...:!
+<reboot initi.... cake...%%&/(
+2017-08-07 19:57:35 - WARNING
+Test subject refused to euthenize Companion Cube
+Waiting two more minutes
+2017-08-07 19:57:35 - FATAL
+Test subject reached sanctuary
+Initiating defenses
+Deploying turrets
+2017-08-07 19:57:37 - ERROR - but only one line really


### PR DESCRIPTION
In order to check e.g. DB2 log files, we required check_logfiles to check for patterns in log-messages which span multiple lines.

The changes in this pull request introduce two options to check_logfiles searches:
**multiline**: if this is on, scanning of a log file will change so that multiple lines are read before the rest of the scan logic is executed. Lines read are identified by a pattern which must be given in the **multilinestartpattern** options, described below.
**multilinestartpattern**: this is a pattern, identifying how a log line starts in multi-line logs. In a DB2 diag-log file this would always be a date/time combination. The scan method then takes the first line which matches this pattern and concatenates each following line as long as it does NOT match this pattern.