### PR TITLE
Feature/postgresql search

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles.pm
@@ -274,7 +274,7 @@ sub init_from_file {
     }
     # We might need this for a pidfile
   }
-
+  
   $self->merge_macros($MACROS); # merge the defaultmacros with macros from the file
   $seekfilesdir ||= $self->{seekfilesdir};
   $protocolsdir ||= $self->{protocolsdir};
@@ -3076,6 +3076,7 @@ sub scan {
               $self->{macros}->{CL_SERVICEOUTPUT} = $line;
               $self->{macros}->{CL_PATTERN_PATTERN} = $pattern;
               $self->{macros}->{CL_PATTERN_NUMBER} = $patcnt;
+              $self->{macros}->{CL_MATCHEDOUTPUT} = $line;
               if (exists $self->{patternkeys}->{$level}->{$pattern} &&
                   defined $self->{patternkeys}->{$level}->{$pattern}) {
                 $self->{macros}->{CL_PATTERN_KEY} = 

--- a/plugins-scripts/Nagios/CheckLogfiles/Search/Postgresql.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles/Search/Postgresql.pm
@@ -1,0 +1,201 @@
+package Nagios::CheckLogfiles::Search::Postgresql;
+
+=head1 NAME
+
+Nagios::CheckLogfiles::Postgresql - Postgresql extension for check_logfiles.
+
+=head1 METHODS
+
+=over 4
+
+=cut
+
+use strict;
+use Exporter;
+use Params::Validate qw(validate :types);
+use vars qw(@ISA);
+
+=head2 B<getSearch()> Create a check_logfiles search hash for Postgresql
+
+This method creates a check_logfiles search hash containing all necessary data for
+
+check_logfiles to perform Postresql logfile checking. The search hash returned here
+
+will take into account the log format prefix definition and will match exactly from the first
+
+occurrence of given log format prefix definition just before the next one.
+
+It is then checked for the position of "%e" within the format definition which represents
+
+the SQL state. Any value other than "00000" will raise an error.
+
+B<Return values>
+
+=over 4
+
+A search hash as required by check_logfiles searches.
+
+=back
+
+B<Attributes>
+
+The following attributes are not given as HASH but sequentially, in the order described below.
+
+=over 4
+
+=item B<tag> - the search tag used for chack_logfiles searches
+
+=item B<logfile> - the logfile to be checked
+
+=item B<logLinePrefix> - the log line prefix definition
+
+=back
+
+=cut
+
+sub getSearch() {
+    my $self = shift;
+
+    my ( $tag, $logfile, $postgresLoglinePrefix ) = @_;
+
+    # use compiled log postgresql log prefix as multiline-start recognition pattern
+    #
+    my $multilinestartpattern = $self->_postgresqlFormatToPattern( logLinePrefix => $postgresLoglinePrefix );
+    
+    return ( {
+            tag                   => "$tag",
+            multiline             => 1,
+            multilinestartpattern => $multilinestartpattern,
+            logfile               => "$logfile",
+            criticalpatterns      => [ ".*" ],
+            options               => 'script,supersmartscript',
+            scriptparams          => "$multilinestartpattern",
+            script                => sub {
+                
+                my $multilinestartpattern = shift;
+                my $matchedOutput    = $ENV{CHECK_LOGFILES_MATCHEDOUTPUT};
+                chomp( $matchedOutput );
+
+                # get the sql state
+                # this is the first matching group
+                # TODO fine tune matching groups to get sqlstate, message, date... etc
+                # TODO implement named groups if available (Perl 5.10+)
+                #
+                my $sqlState = "00000";
+
+                if ( $matchedOutput =~ /$multilinestartpattern/ ) {
+                    $sqlState = $1;
+                }
+
+                # print plugin output
+                #
+                print( $matchedOutput );
+
+                # any other sql state than "00000" will result in critical(2) plugin return value
+                #
+                if ( $sqlState ne "00000" ) {
+                    return 2;
+                }
+
+                return 0;
+            }
+        } );
+}
+
+=head2 B<_postgresqlFormatToPattern()> Get a pattern for a postgresql log prefix format
+
+This method transforms a given postgresql log prefix format string into a regex pattern
+
+which can be used to identify log lines within a postgresql log file. The only matching
+
+group will be placed around "%e" substitution, so that the SQL state can be matched with
+
+the returned substituted pattern.
+
+The following substitutions are used:
+
+     format  | description                                         | substitution
+    ---------+-----------------------------------------------------+--------------
+       %a    | Application name                                    | \S+
+       %u    | User name                                           | \S+
+       %d    | Database name                                       | \S+
+       %r    | Remote host name or IP address, and remote port     | \S+:\d+
+       %h    | Remote host name or IP address                      | \S+
+       %p    | Process ID                                          | \d+
+       %t    | Time stamp without milliseconds                     | \d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2} \S+
+       %m    | Time stamp with milliseconds                        | \d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}\.\d+ \S+
+       %i    | Command tag: type of session's current command      | \S+
+       %e    | SQLSTATE error code                                 | (\S{5})
+       %c    | Session ID: see below                               | \S\S\.\S\S
+       %l    | Number of the log line for each session or process, | \d+ 
+             | starting at 1                                       |
+       %s    | Process start time stamp                            | \d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2} \S+
+       %v    | Virtual transaction ID (backendID/localXID)         | \d+
+       %x    | Transaction ID (0 if none is assigned)              | \d+
+       %q    | Produces no output, but tells non-session processes | <empty string>, but everything after will be 
+             | to stop at this point in the string;                | made an optional match -> (...)?
+             | ignored by session processes                        | 
+       %%    | Literal %                                           | %
+
+Additionally all regex specific characters will be escaped.
+
+B<Return values>
+
+=over 4
+
+The pattern which can be used to identify log lines
+
+=back
+
+B<Attributes>
+
+=over 4
+
+=item B<logLinePrefix> - the log line prefix definition to transform
+
+=back
+
+=cut
+
+sub _postgresqlFormatToPattern {
+    my $self = shift;
+
+    my %attributes = validate( @_, { logLinePrefix => { type => SCALAR } } );
+
+    my $pattern = $attributes{'logLinePrefix'};
+
+    # escape regex specific characters
+    #
+    $pattern =~ s/([\?\-\+\.\(\)\[\]\{\}\*\^\$])/\\$1/g;
+
+    # substitutions
+    #
+    $pattern =~ s/%[audhi]/\\S+/g;
+
+    $pattern =~ s/%[plvx]/\\d+/g;
+
+    $pattern =~ s/%r/\\S+:\\d+/g;
+
+    $pattern =~ s/%[ts]/\\d{4}\\-\\d{2}\\-\\d{2} \\d{2}:\\d{2}:\\d{2} \\S+/g;
+
+    $pattern =~ s/%m/\\d{4}\\-\\d{2}\\-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d+ \\S+/g;
+
+    $pattern =~ s/%c/\\S\\S\\.\\S\\S/g;
+
+    $pattern =~ s/%%/%/g;
+
+    $pattern =~ s/%e/(\\S{5})/g;
+
+    # handle "%q"
+    # everything after this is an optional match
+    #
+    $pattern =~ s/%q(.+)$/($1)?/g;
+
+    return $pattern;
+}
+
+=back
+
+=cut
+
+1;

--- a/t/110multiline.t
+++ b/t/110multiline.t
@@ -1,0 +1,59 @@
+#!/usr/bin/perl -w
+#
+#  110multiline.t
+#
+#  Test multiline parsing
+#
+
+use strict;
+use Test::More tests => 3;
+use Cwd;
+use lib "../plugins-scripts";
+use Nagios::CheckLogfiles::Test;
+use constant TESTDIR => ".";
+
+my $configfile = <<EOCFG;
+\$protocolsdir = "./var/tmp";
+\$seekfilesdir = "./var/tmp";
+
+\@searches = (
+  {
+    tag => 'multiline',
+    options => 'allyoucaneat',
+    multiline   => 1,
+    multilinestartpattern => '\\d{4}\\-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\- ',
+    logfile => './data/multiline.log',
+    criticalpatterns => [ 'ERROR' ]
+  },
+);
+
+EOCFG
+open CCC, ">./etc/multiline.cfg";
+print CCC $configfile;
+close CCC;
+
+my $cl = Nagios::CheckLogfiles::Test->new({ cfgfile => "./etc/multiline.cfg" });
+$cl->reset();
+$cl->run();
+diag($cl->has_result());
+diag($cl->{exitmessage});
+
+my ($protocolFile) = glob( "./var/tmp/multiline.protocol*" );
+open( PROTOCOL, "<$protocolFile" ) || fail( "Could not open protocol file '$protocolFile': $!" );
+my @content = <PROTOCOL>;
+close( PROTOCOL );
+
+my $expectedContent = qq|CRITICAL Errors in multiline.log (tag multiline)
+2017-08-07 19:51:02 - ERROR
+Test subject glitched through catcher
+Cake reward will be reduced
+2017-08-07 19:51:09 - ERROR
+.....<bzzzt>.....>...\$\%\&...:!
+<reboot initi.... cake...\%\%\&/(
+2017-08-07 19:57:37 - ERROR - but only one line really
+|;
+
+is(join( "", @content ), $expectedContent ); 
+like($cl->{exitmessage}, qr/CRITICAL - \(3 errors in multiline.protocol-.+\) - 2017-08-07 19:57:37 - ERROR - but only one line really .../ );
+ok($cl->expect_result(0, 0, 3, 0, 2));
+

--- a/t/120postgresql.t
+++ b/t/120postgresql.t
@@ -1,0 +1,61 @@
+#!/usr/bin/perl -w
+#
+#  120postgresql.t
+#
+#  Test postgresql log checking
+#
+
+use strict;
+use Test::More tests => 3;
+use Cwd;
+use lib "../plugins-scripts";
+use Nagios::CheckLogfiles::Test;
+use constant TESTDIR => ".";
+
+use Nagios::CheckLogfiles::Search::Postgresql;
+
+my $configfile = q|
+$protocolsdir = "./var/tmp";
+$seekfilesdir = "./var/tmp";
+
+$tag = 'postgresql';
+$logfile = './data/postgresql.log';
+$postgresLoglinePrefix='%t [%p-%l] (%e) %q%u@%d (%a) ';
+
+@searches = Nagios::CheckLogfiles::Search::Postgresql->getSearch( $tag, $logfile, $postgresLoglinePrefix );
+
+$searches[0]->{options} = $searches[0]->{options} . ",allyoucaneat";
+|;
+
+open CCC, ">./etc/postgresql.cfg";
+print CCC $configfile;
+close CCC;
+
+my $cl = Nagios::CheckLogfiles::Test->new({ cfgfile => "./etc/postgresql.cfg" });
+$cl->reset();
+$cl->run();
+diag($cl->has_result());
+diag($cl->{exitmessage});
+
+my ($protocolFile) = glob( "./var/tmp/postgresql.protocol*" );
+open( PROTOCOL, "<$protocolFile" ) || fail( "Could not open protocol file '$protocolFile': $!" );
+my @content = <PROTOCOL>;
+close( PROTOCOL );
+
+my $expectedContent = q|CRITICAL Errors in postgresql.log (tag postgresql)
+2017-10-13 09:27:27 CEST [16992-1] (00042) LOG:  automatic vacuum of table "template1.pg_catalog.pg_class": index scans: 1
+        pages: 0 removed, 14 remain, 0 skipped due to pins, 0 skipped frozen
+        tuples: 7 removed, 316 remain, 0 are dead but not yet removable
+        buffer usage: 89 hits, 0 misses, 1 dirtied, 6 multilines
+        avg read rate: 0.000 MB/s, avg write rate: 8.130 MB/s - and this is very bad!
+        system usage: CPU 0.00s/0.00u sec elapsed 0.00 sec
+2017-10-13 09:27:49 CEST [17075-1] (XFLR6) [unknown]@[unknown] ([unknown]) LOG:  connection received: host=[local] - destination "moon" is not reachable
+2017-10-13 09:27:49 CEST [17075-2] (01337) instance3@instance3 ([unknown]) LOG:  connection authorized: user=instance3 database=instance3 - no way!
+2017-10-13 09:29:39 CEST [29236-2] (MLLIA) instance3@instance3 ([unknown]) LOG:  connection authorized: user=instance3 database=instance3 - anagrams unsupported
+2017-10-13 09:30:26 CEST [29445-1] (12345) [unknown]@[unknown] ([unknown]) LOG:  connection received: host=[local] - even the last line should be detected
+|;
+
+is(join( "", @content ), $expectedContent ); 
+like($cl->{exitmessage}, qr/CRITICAL - \(5 errors in postgresql.protocol-.+\) - 2017-10-13 09:30:26 CEST/ );
+ok($cl->expect_result(14, 0, 5, 0, 2));
+

--- a/t/data/multiline.log
+++ b/t/data/multiline.log
@@ -1,0 +1,20 @@
+2017-08-07 19:51:00 - INFO
+Testchamber 16 initialized
+Number of portals set to seven
+2017-08-07 19:51:02 - ERROR
+Test subject glitched through catcher
+Cake reward will be reduced
+2017-08-07 19:51:07 - INFO
+Testchamber 17 initialized
+Test subject entered with fully upgraded Portal Gun
+2017-08-07 19:51:09 - ERROR
+.....<bzzzt>.....>...$%&...:!
+<reboot initi.... cake...%%&/(
+2017-08-07 19:57:35 - WARNING
+Test subject refused to euthenize Companion Cube
+Waiting two more minutes
+2017-08-07 19:57:35 - FATAL
+Test subject reached sanctuary
+Initiating defenses
+Deploying turrets
+2017-08-07 19:57:37 - ERROR - but only one line really

--- a/t/data/postgresql.log
+++ b/t/data/postgresql.log
@@ -1,0 +1,34 @@
+2017-10-13 09:27:01 CEST [16621-2] (00000) instance3@instance3 ([unknown]) LOG:  connection authorized: user=instance3 database=instance3
+2017-10-13 09:27:01 CEST [16621-3] (00000) instance3@instance3 (psql) LOG:  disconnection: session time: 0:00:00.006 user=instance3 database=instance3 host=[local]
+2017-10-13 09:27:01 CEST [16694-1] (00000) [unknown]@[unknown] ([unknown]) LOG:  connection received: host=[local]
+2017-10-13 09:27:01 CEST [16694-2] (00000) instance3@instance3 ([unknown]) LOG:  connection authorized: user=instance3 database=instance3
+2017-10-13 09:27:01 CEST [16694-3] (00000) instance3@instance3 (psql) LOG:  disconnection: session time: 0:00:00.002 user=instance3 database=instance3 host=[local]
+2017-10-13 09:27:27 CEST [16992-1] (00042) LOG:  automatic vacuum of table "template1.pg_catalog.pg_class": index scans: 1
+        pages: 0 removed, 14 remain, 0 skipped due to pins, 0 skipped frozen
+        tuples: 7 removed, 316 remain, 0 are dead but not yet removable
+        buffer usage: 89 hits, 0 misses, 1 dirtied, 6 multilines
+        avg read rate: 0.000 MB/s, avg write rate: 8.130 MB/s - and this is very bad!
+        system usage: CPU 0.00s/0.00u sec elapsed 0.00 sec
+2017-10-13 09:27:27 CEST [16992-2] (00000) LOG:  automatic analyze of table "template1.pg_catalog.pg_class" system usage: CPU 0.00s/0.00u sec elapsed 0.02 sec
+2017-10-13 09:27:27 CEST [16992-3] (00000) LOG:  automatic analyze of table "template1.pg_catalog.pg_shdepend" system usage: CPU 0.00s/0.00u sec elapsed 0.00 sec
+2017-10-13 09:27:47 CEST [16996-1] (00000) LOG:  automatic vacuum of table "instance3.pg_catalog.pg_class": index scans: 1
+        pages: 0 removed, 15 remain, 0 skipped due to pins, 0 skipped frozen
+        tuples: 20 removed, 317 remain, 0 are dead but not yet removable
+        buffer usage: 93 hits, 0 misses, 1 dirtied
+        avg read rate: 0.000 MB/s, avg write rate: 12.094 MB/s
+        system usage: CPU 0.00s/0.00u sec elapsed 0.00 sec
+2017-10-13 09:27:47 CEST [16996-2] (00000) LOG:  automatic analyze of table "instance3.pg_catalog.pg_class" system usage: CPU 0.00s/0.00u sec elapsed 0.02 sec
+2017-10-13 09:27:49 CEST [17075-1] (XFLR6) [unknown]@[unknown] ([unknown]) LOG:  connection received: host=[local] - destination "moon" is not reachable
+2017-10-13 09:27:49 CEST [17075-2] (01337) instance3@instance3 ([unknown]) LOG:  connection authorized: user=instance3 database=instance3 - no way!
+2017-10-13 09:27:50 CEST [17075-3] (00000) instance3@instance3 (psql) LOG:  disconnection: session time: 0:00:01.764 user=instance3 database=instance3 host=[local]
+2017-10-13 09:28:07 CEST [19373-1] (00000) LOG:  automatic vacuum of table "postgres.pg_catalog.pg_class": index scans: 1
+        pages: 0 removed, 14 remain, 0 skipped due to pins, 0 skipped frozen
+        tuples: 7 removed, 316 remain, 0 are dead but not yet removable
+        buffer usage: 89 hits, 0 misses, 1 dirtied
+        avg read rate: 0.000 MB/s, avg write rate: 12.094 MB/s
+        system usage: CPU 0.00s/0.00u sec elapsed 0.00 sec
+2017-10-13 09:28:07 CEST [19373-2] (00000) LOG:  automatic analyze of table "postgres.pg_catalog.pg_class" system usage: CPU 0.00s/0.00u sec elapsed 0.02 sec
+2017-10-13 09:29:39 CEST [29236-1] (00000) [unknown]@[unknown] ([unknown]) LOG:  connection received: host=[local]
+2017-10-13 09:29:39 CEST [29236-2] (MLLIA) instance3@instance3 ([unknown]) LOG:  connection authorized: user=instance3 database=instance3 - anagrams unsupported
+2017-10-13 09:29:39 CEST [29236-3] (00000) instance3@instance3 (psql) LOG:  disconnection: session time: 0:00:00.002 user=instance3 database=instance3 host=[local]
+2017-10-13 09:30:26 CEST [29445-1] (12345) [unknown]@[unknown] ([unknown]) LOG:  connection received: host=[local] - even the last line should be detected


### PR DESCRIPTION
This is a feature which is based on the previous pull request (multiline parsing support).

Postgresql database logs, too, are multiline (well sometimes). Additionally the starting pattern of  log line is conifgurable via the Postgresql variable log_line_prefix.

This Plugin takes care of the translation of said prefix to a multilinestartpattern and also handles plugin return values via a script.