### PR TITLE
Add Ubuntu log rotation pattern

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles.pm
@@ -3806,6 +3806,9 @@ sub prepare {
   } elsif ("DEBIAN" eq uc($self->{rotation})) {
     $self->{filenamepattern} = sprintf "%s.0|%s.*[0-9]*.gz",
         $self->{logbasename}, $self->{logbasename};
+  } elsif ("UBUNTU" eq uc($self->{rotation})) {
+    $self->{filenamepattern} = sprintf "%s.1|%s.*[0-9]*.gz",
+        $self->{logbasename}, $self->{logbasename};        
   } elsif ("QMAIL" eq uc($self->{rotation})) {
     $self->{filenamepattern} = "\@.*";
   } elsif ("LOGROTATE" eq uc($self->{rotation})) {


### PR DESCRIPTION
Files are rotated by default on Ubuntu in the following manner:
log.txt
log.txt.1
log.txt.2.gz
...