### PR TITLE
Add abiltiy to search systemd journals by syslog identifiers. Debian …

### DIFF
--- a/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
+++ b/plugins-scripts/Nagios/CheckLogfiles/Search/Journald.pm
@@ -26,6 +26,7 @@ sub init {
   if ($self->{journaldunit} and $self->{tag} eq "default") {
     $self->{tag} = $self->{journaldunit};
   }
+  $self->{journaldidentifier} = $params->{journald}->{identifier};
   $self->default_options({ exeargs => "", });
   $self->SUPER::init($params);
 }
@@ -48,6 +49,9 @@ sub collectfiles {
     my $cmdline = $self->{logfile};
     if ($self->{journaldunit}) {
       $cmdline = $cmdline." --unit '".$self->{journaldunit}."'";
+    }
+    if ($self->{journaldidentifier}) {
+      $cmdline = $cmdline." --identifier '".$self->{journaldidentifier}."'";
     }
     $cmdline = $cmdline." --since '".strftime("%Y-%m-%d %H:%M:%S", localtime($self->{journald}->{since}))."'|";
     if ($fh->open($cmdline)) {

--- a/plugins-scripts/Nagios/Tivoli/Config/Logfile.pm
+++ b/plugins-scripts/Nagios/Tivoli/Config/Logfile.pm
@@ -5,6 +5,8 @@
 #          tivoli config files and
 #          return it as hash structure
 #
+# John Lines  update to filter on journald:identifier
+#  to allow, for example --type=journald:identifier='postfix/smtp'
 package Nagios::Tivoli::Config::Logfile;
 
 use strict;


### PR DESCRIPTION
See Debian Bug#1060859.

> I scan mail logs for Deliverable Status Notifications for 'dsn=5.7" on
my delivery server, so if some recipient starts blocking the server I
can start investigating and switch to a different outbound server before
users start to report that 'mail is not working'.

> For systems where mail logs are in /var/log/mail.log this is simple, but
where they are in the systemd journal a scan which looks only at, in
this case, entries with a SYSLOG_IDENTIFIER of 'postfix/smtp' is more
effective.

> The attached patch allows an argument of 
 --type=journald:identifier='postfix/smtp' 
to be specified.